### PR TITLE
Fixing typos 0218 and 0219 to 2018 and 2019

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,7 @@ const [tags, entryCount, entries] = <u>await</u> Promise.all([
 
         <section data-state="theme-color-forest-yellow">
           <section id="es2018">
-            <h1>ES0218</h1>
+            <h1>ES2018</h1>
             <h4>(As per feature freezing in January 2018, may still expand)</h4>
           </section>
 
@@ -410,7 +410,7 @@ windowsPath`C:\uuu\xxx\088` // Despite \uu, \xx and \08 not being valid escapes
 
         <section data-state="theme-color-blue-yellow">
           <section id="es2019-es2020">
-            <h1>ES0219 &amp; ES2020</h1>
+            <h1>ES2019 &amp; ES2020</h1>
             <h4>chosen bits that’ll probably show up (stages 2–3)</h4>
 
             <footer>(Next to no native support just now, FYI)</footer>


### PR DESCRIPTION
Just found your notes and noticed this typo - 

Thanks for the cool summary!